### PR TITLE
ENH: support bytearray and unicode (#3)

### DIFF
--- a/better_bencode/_pure.py
+++ b/better_bencode/_pure.py
@@ -30,6 +30,7 @@ else:
     BINARY_TYPES = (bytes, )
     int_to_binary = lambda val: bytes(str(val), 'ascii')
     unicode_to_bytes = lambda val: bytes(val, 'utf8')
+    unicode = str
 
 
 class BencodeValueError(ValueError):

--- a/better_bencode/_pure.py
+++ b/better_bencode/_pure.py
@@ -24,10 +24,12 @@ if sys.version_info[0] == 2:
     INTEGER_TYPES = (int, long)
     BINARY_TYPES = (str, )
     int_to_binary = lambda val: str(val)
+    unicode_to_bytes = lambda val: bytes(val)
 else:
     INTEGER_TYPES = (int,)
     BINARY_TYPES = (bytes, )
     int_to_binary = lambda val: bytes(str(val), 'ascii')
+    unicode_to_bytes = lambda val: bytes(val, 'utf8')
 
 
 class BencodeValueError(ValueError):
@@ -59,6 +61,11 @@ def _dump_implementation(obj, write, path, cast):
         for item in obj:
             _dump_implementation(item, write, path + [id(obj)], cast)
         write(b'e')
+    elif t is bytearray:
+        _dump_implementation(bytes(obj), write, path + [id(obj)], cast)
+    elif t is unicode:
+        _dump_implementation(unicode_to_bytes(obj), write,
+                             path + [id(obj)], cast)
     elif t is dict:
         write(b'd')
 

--- a/tests/test_bencode.py
+++ b/tests/test_bencode.py
@@ -65,6 +65,8 @@ TEST_DATA = [
     (b'd3:bar4:spam3:fooi42ee', {b'bar': b'spam', b'foo': 42}),
     (b'd1:ai1e1:bi2e1:ci3ee', {b'a': 1, b'b': 2, b'c': 3}),
     (b'd1:a1:be', {b'a': b'b'}),
+    (b'3:\x00\x01\x02', bytearray([0, 1, 2])),
+    (b'3:abc', bytearray('abc', 'ascii'))
 ]
 TESTS = [
     (module,) + test

--- a/tests/test_bencode.py
+++ b/tests/test_bencode.py
@@ -104,7 +104,7 @@ TESTS_TYPEERROR = [
     (module,  test)
     for module in MODULES
     for test in [
-        u'', (), set(), frozenset(),
+        (), set(), frozenset(),
         len, TypeError,
         True, False, None, 1.0,
     ]


### PR DESCRIPTION
- #3 
- [x] TST: manual test bencode.dumps with Python 2
- [x] TST: manual test bencode.dumps with Python 3
- [x] TST: test that a .torrent file at least loads (with Transmission)
  - [ ] is this handling of utf8 unicode strings consistent with which BEP?
    - https://wiki.theory.org/BitTorrentSpecification#Metainfo_File_Structure
      " All character string values are UTF-8 encoded."
- [x] TST: write test cases for bytearrays
- [ ] TST: write test cases for unicodes
- [ ] PRF: port to _fast.c