### PR TITLE
Update docstring for dumps: it returns bytes in the context of Python 3

### DIFF
--- a/better_bencode/_fast.c
+++ b/better_bencode/_fast.c
@@ -553,7 +553,7 @@ static PyMethodDef better_bencode_fastMethods[] = {
     {"load", load, METH_VARARGS, "Deserialize ``fp`` to a Python object."},
     {"loads", loads, METH_VARARGS, "Deserialize ``s`` to a Python object."},
     {"dump", dump, METH_VARARGS|METH_KEYWORDS, "Serialize ``obj`` as a Bencode formatted stream to ``fp``."},
-    {"dumps", dumps, METH_VARARGS|METH_KEYWORDS, "Serialize ``obj`` to a Bencode formatted ``str``."},
+    {"dumps", dumps, METH_VARARGS|METH_KEYWORDS, "Serialize ``obj`` to a Bencode formatted ``bytes``."},
     {NULL, NULL, 0, NULL}
 };
 

--- a/better_bencode/_pure.py
+++ b/better_bencode/_pure.py
@@ -84,7 +84,7 @@ def dump(obj, fp, cast=False):
 
 
 def dumps(obj, cast=False):
-    """Serialize ``obj`` to a Bencode formatted ``str``."""
+    """Serialize ``obj`` to a Bencode formatted ``bytes``."""
 
     fp = []
     _dump_implementation(obj, fp.append, [], cast)

--- a/tests/test_bencode.py
+++ b/tests/test_bencode.py
@@ -236,7 +236,7 @@ def test_docstrings_dump(module):
 
 @pytest.mark.parametrize('module', MODULES)
 def test_docstrings_dumps(module):
-    assert module.dumps.__doc__ == "Serialize ``obj`` to a Bencode formatted ``str``."
+    assert module.dumps.__doc__ == "Serialize ``obj`` to a Bencode formatted ``bytes``."
 
 
 @pytest.mark.parametrize('module', MODULES)


### PR DESCRIPTION
Update docstring for dumps: it returns bytes in the context of Python 3.

It's probably safe to ignore python < 2.7 for the purpose of documentation at
this point).
