### PR TITLE
Run tox tests on Python 3 up to 3.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,pypy,py33,py34,py35
+envlist=py26,py27,pypy,py33,py34,py35,py36,py37,py38,py39
 
 [testenv]
 changedir=tests


### PR DESCRIPTION
Run tox tests on Python 3 up to 3.9.
